### PR TITLE
Constant presences

### DIFF
--- a/app/src/app.module.ts
+++ b/app/src/app.module.ts
@@ -3,6 +3,7 @@ import { BoltModule } from "./bolt/bolt.module";
 import { ConfigModule } from "./common/config/config.module";
 import { DatabaseModule } from "./database/database.module";
 import { DevToolsModule } from "./dev-tools/dev-tools.module";
+import { ConstantPresenceModule } from "./entities/constant-presence/constant-presence.module";
 import { EntitiesModule } from "./entities/entities.module";
 import { GuiModule } from "./gui/gui.module";
 import { SyncModule } from "./sync/sync.module";
@@ -15,6 +16,7 @@ import { SyncModule } from "./sync/sync.module";
     EntitiesModule,
     SyncModule,
     GuiModule,
+    ConstantPresenceModule,
     // Non-production modules.
     ...(process.env.NODE_ENV === "development" ? [DevToolsModule] : []),
   ],

--- a/app/src/bolt/enums/action.enum.ts
+++ b/app/src/bolt/enums/action.enum.ts
@@ -16,6 +16,7 @@ enum Action {
   OPEN_EDIT_OFFICE_MODAL = "open_edit_office_modal",
   DELETE_OFFICE = "delete_office",
   SET_HOME_OFFICE = "set_home_office",
+  OPEN_CONSTANT_PRESENCE_MANAGEMENT_MODAL = "open_constant_presence_management_modal",
 }
 
 export default Action;

--- a/app/src/bolt/enums/action.enum.ts
+++ b/app/src/bolt/enums/action.enum.ts
@@ -17,6 +17,7 @@ enum Action {
   DELETE_OFFICE = "delete_office",
   SET_HOME_OFFICE = "set_home_office",
   OPEN_CONSTANT_PRESENCE_MANAGEMENT_MODAL = "open_constant_presence_management_modal",
+  DELETE_CONSTANT_PRESENCE = "delete_constant_presence",
 }
 
 export default Action;

--- a/app/src/bolt/enums/view-action.enum.ts
+++ b/app/src/bolt/enums/view-action.enum.ts
@@ -1,6 +1,7 @@
 enum ViewAction {
   CREATE_OFFICE = "create_office",
   EDIT_OFFICE = "edit_office",
+  SAVE_CONSTANT_PRESENCES = "save_constant_presences",
 }
 
 export default ViewAction;

--- a/app/src/common/dayjs.ts
+++ b/app/src/common/dayjs.ts
@@ -1,8 +1,10 @@
 import _dayjs from "dayjs";
 import "dayjs/locale/fi";
+import weekday from "dayjs/plugin/weekday";
 
 const dayjs = _dayjs;
 
 dayjs.locale("fi");
+dayjs.extend(weekday);
 
 export default dayjs;

--- a/app/src/common/exceptions/user-group-not-found.exception.ts
+++ b/app/src/common/exceptions/user-group-not-found.exception.ts
@@ -1,0 +1,8 @@
+import { HttpStatus } from "@nestjs/common";
+import { KaikuAppException } from "./kaiku-app.exception";
+
+export class UserGroupNotFoundException extends KaikuAppException {
+  constructor() {
+    super("User group was not found in Slack workspace.", HttpStatus.NOT_FOUND);
+  }
+}

--- a/app/src/database/migrations/1735653188488-create-constant-presence-table.ts
+++ b/app/src/database/migrations/1735653188488-create-constant-presence-table.ts
@@ -65,6 +65,11 @@ export class AddConstantPresenceTable1735653188488 implements MigrationInterface
         ],
       }),
     );
+
+    // Default B-tree index is not effective with the daterange type.
+    await queryRunner.query(
+      "CREATE INDEX in_effect_index ON constant_presence USING GIST (in_effect)",
+    );
   }
 
   public async down(): Promise<void> {}

--- a/app/src/database/migrations/1735653188488-create-constant-presence-table.ts
+++ b/app/src/database/migrations/1735653188488-create-constant-presence-table.ts
@@ -1,0 +1,71 @@
+import { MigrationInterface, QueryRunner, Table } from "typeorm";
+
+export class AddConstantPresenceTable1735653188488 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: "constant_presence",
+        columns: [
+          {
+            name: "id",
+            type: "uuid",
+            isPrimary: true,
+            default: "uuid_generate_v4()",
+          },
+          {
+            name: "user_slack_id",
+            type: "text",
+            isNullable: false,
+          },
+          {
+            name: "in_effect",
+            type: "daterange",
+            isNullable: false,
+          },
+          {
+            name: "day_of_week",
+            type: "integer",
+            isNullable: false,
+            unsigned: true,
+          },
+          {
+            name: "remote",
+            type: "boolean",
+            isNullable: false,
+            default: false,
+          },
+          {
+            name: "office_id",
+            type: "uuid",
+          },
+          {
+            name: "created_at",
+            type: "timestamp",
+            isNullable: false,
+            default: "now()",
+          },
+          {
+            name: "updated_at",
+            type: "timestamp",
+            isNullable: false,
+            default: "now()",
+          },
+        ],
+        foreignKeys: [
+          {
+            columnNames: ["user_slack_id"],
+            referencedTableName: "user",
+            referencedColumnNames: ["slack_id"],
+          },
+          {
+            columnNames: ["office_id"],
+            referencedTableName: "office",
+            referencedColumnNames: ["id"],
+          },
+        ],
+      }),
+    );
+  }
+
+  public async down(): Promise<void> {}
+}

--- a/app/src/entities/constant-presence/constant-presence.model.ts
+++ b/app/src/entities/constant-presence/constant-presence.model.ts
@@ -5,10 +5,12 @@ import {
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
+  Repository,
   UpdateDateColumn,
 } from "typeorm";
 import { Office } from "../office/office.model";
 import { User } from "../user/user.model";
+import { DateRange, daterangeTransformer } from "./daterange-transformer";
 
 @Entity()
 export class ConstantPresence {
@@ -19,9 +21,13 @@ export class ConstantPresence {
   @JoinColumn({ name: "user_slack_id" })
   user: User;
 
-  // TODO: Add transformer.
-  @Column({ name: "in_effect", type: "daterange", nullable: false })
-  inEffect: string;
+  @Column({
+    name: "in_effect",
+    type: "daterange",
+    nullable: false,
+    transformer: daterangeTransformer,
+  })
+  inEffect: DateRange;
 
   @Column({ name: "day_of_week", type: "integer", nullable: false, unsigned: true })
   dayOfWeek: number;
@@ -39,3 +45,5 @@ export class ConstantPresence {
   @UpdateDateColumn({ name: "updated_at" })
   updatedAt: Date;
 }
+
+export type ConstantPresenceRepository = Repository<ConstantPresence>;

--- a/app/src/entities/constant-presence/constant-presence.model.ts
+++ b/app/src/entities/constant-presence/constant-presence.model.ts
@@ -1,0 +1,41 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from "typeorm";
+import { Office } from "../office/office.model";
+import { User } from "../user/user.model";
+
+@Entity()
+export class ConstantPresence {
+  @PrimaryGeneratedColumn("uuid")
+  id: string;
+
+  @ManyToOne(() => User, { nullable: false, eager: true })
+  @JoinColumn({ name: "user_slack_id" })
+  user: User;
+
+  // TODO: Add transformer.
+  @Column({ name: "in_effect", type: "daterange", nullable: false })
+  inEffect: string;
+
+  @Column({ name: "day_of_week", type: "integer", nullable: false, unsigned: true })
+  dayOfWeek: number;
+
+  @Column({ name: "remote", type: "boolean", nullable: false, default: false })
+  remote: boolean;
+
+  @ManyToOne(() => Office, { nullable: true, eager: true })
+  @JoinColumn({ name: "office_id" })
+  office: Office | null;
+
+  @CreateDateColumn({ name: "created_at" })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: "updated_at" })
+  updatedAt: Date;
+}

--- a/app/src/entities/constant-presence/constant-presence.module.ts
+++ b/app/src/entities/constant-presence/constant-presence.module.ts
@@ -1,6 +1,11 @@
 import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { ConstantPresence } from "./constant-presence.model";
+import { ConstantPresenceService } from "./constant-presence.service";
 
-@Module({ imports: [TypeOrmModule.forFeature([ConstantPresence])], exports: [TypeOrmModule] })
+@Module({
+  imports: [TypeOrmModule.forFeature([ConstantPresence])],
+  providers: [ConstantPresenceService],
+  exports: [TypeOrmModule, ConstantPresenceService],
+})
 export class ConstantPresenceModule {}

--- a/app/src/entities/constant-presence/constant-presence.module.ts
+++ b/app/src/entities/constant-presence/constant-presence.module.ts
@@ -1,0 +1,6 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { ConstantPresence } from "./constant-presence.model";
+
+@Module({ imports: [TypeOrmModule.forFeature([ConstantPresence])], exports: [TypeOrmModule] })
+export class ConstantPresenceModule {}

--- a/app/src/entities/constant-presence/constant-presence.service.ts
+++ b/app/src/entities/constant-presence/constant-presence.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import dayjs from "../../common/dayjs";
+import { ConstantPresence, ConstantPresenceRepository } from "./constant-presence.model";
+import { CreateConstantPresence } from "./dto/create-constant-presence.dto";
+
+@Injectable()
+export class ConstantPresenceService {
+  constructor(
+    @InjectRepository(ConstantPresence)
+    private constantPresenceRepository: ConstantPresenceRepository,
+  ) {}
+
+  // async findEffectiveByUserId(userId: string) {
+  //   return this.constantPresenceRepository
+  //     .createQueryBuilder("cp")
+  //     .select()
+  //     .where("cp.user_slack_id = :userId", { userId })
+  //     .andWhere("in_effect @> NOW()::date")
+  //     .execute();
+  // }
+
+  /**
+   * Create new constant presences for user.
+   *
+   * All currently effective constant presence entries will be closed as of the
+   * current date. New entries will be effective starting on the current date.
+   */
+  async closeOldAndCreateMany(userId: string, cps: CreateConstantPresence[]) {
+    await this.closeEffectiveCpsByUserId(userId);
+
+    const user = { slackId: userId };
+    const inEffect = { start: dayjs(), end: undefined };
+
+    const inserts = cps.map(({ officeId, ...cp }) => ({
+      ...cp,
+      user,
+      inEffect,
+      office: officeId ? { id: officeId } : null,
+    }));
+
+    await this.constantPresenceRepository.save(inserts);
+  }
+
+  private async closeEffectiveCpsByUserId(userId: string) {
+    return this.constantPresenceRepository
+      .createQueryBuilder()
+      .update()
+      .set({ inEffect: () => "daterange(lower(in_effect), NOW()::date)" })
+      .where("user_slack_id = :userId", { userId })
+      .andWhere("in_effect @> NOW()::date")
+      .execute();
+  }
+}

--- a/app/src/entities/constant-presence/constant-presence.service.ts
+++ b/app/src/entities/constant-presence/constant-presence.service.ts
@@ -47,6 +47,8 @@ export class ConstantPresenceService {
     const query = this.constantPresenceRepository
       .createQueryBuilder("cp")
       .select()
+      .leftJoinAndSelect("cp.office", "office")
+      .leftJoinAndSelect("cp.user", "user")
       .where("in_effect && :range", { range: daterangeTransformer.to(range) });
 
     if (filters?.userId) {

--- a/app/src/entities/constant-presence/constant-presence.service.ts
+++ b/app/src/entities/constant-presence/constant-presence.service.ts
@@ -10,6 +10,7 @@ import { CreateConstantPresence } from "./dto/create-constant-presence.dto";
 type ConstantPresenceFilter = {
   userId?: string;
   userGroupHandle?: string;
+  remote?: boolean;
 };
 
 @Injectable()
@@ -54,6 +55,10 @@ export class ConstantPresenceService {
     if (filters?.userGroupHandle) {
       const userIds = await this.getUserGroupUsers(filters.userGroupHandle);
       query.andWhere("user_slack_id IN (:...userIds)", { userIds });
+    }
+
+    if (filters?.remote !== undefined) {
+      query.andWhere("remote = :remote", { remote: filters?.remote });
     }
 
     const res = await query.getRawAndEntities();

--- a/app/src/entities/constant-presence/constant-presence.service.ts
+++ b/app/src/entities/constant-presence/constant-presence.service.ts
@@ -11,14 +11,17 @@ export class ConstantPresenceService {
     private constantPresenceRepository: ConstantPresenceRepository,
   ) {}
 
-  // async findEffectiveByUserId(userId: string) {
-  //   return this.constantPresenceRepository
-  //     .createQueryBuilder("cp")
-  //     .select()
-  //     .where("cp.user_slack_id = :userId", { userId })
-  //     .andWhere("in_effect @> NOW()::date")
-  //     .execute();
-  // }
+  async findEffectiveByUserId(userId: string): Promise<ConstantPresence[]> {
+    const res = await this.constantPresenceRepository
+      .createQueryBuilder("cp")
+      .select()
+      .leftJoinAndSelect("cp.office", "office")
+      .where("cp.user_slack_id = :userId", { userId })
+      .andWhere("in_effect @> NOW()::date")
+      .getRawAndEntities();
+
+    return res.entities;
+  }
 
   /**
    * Create new constant presences for user.

--- a/app/src/entities/constant-presence/constant-presence.service.ts
+++ b/app/src/entities/constant-presence/constant-presence.service.ts
@@ -11,6 +11,7 @@ type ConstantPresenceFilter = {
   userId?: string;
   userGroupHandle?: string;
   remote?: boolean;
+  officeId?: string;
 };
 
 @Injectable()
@@ -59,6 +60,11 @@ export class ConstantPresenceService {
 
     if (filters?.remote !== undefined) {
       query.andWhere("remote = :remote", { remote: filters?.remote });
+    }
+
+    if (filters?.officeId) {
+      query.andWhere("remote = FALSE");
+      query.andWhere("office_id = :officeId", { officeId: filters.officeId });
     }
 
     const res = await query.getRawAndEntities();

--- a/app/src/entities/constant-presence/constant-presence.service.ts
+++ b/app/src/entities/constant-presence/constant-presence.service.ts
@@ -54,4 +54,15 @@ export class ConstantPresenceService {
       .andWhere("in_effect @> NOW()::date")
       .execute();
   }
+
+  async closeEffectiveCpsByUserIdAndDayOfWeek(userId: string, dayOfWeek: number) {
+    return this.constantPresenceRepository
+      .createQueryBuilder()
+      .update()
+      .set({ inEffect: () => "daterange(lower(in_effect), NOW()::date)" })
+      .where("user_slack_id = :userId", { userId })
+      .andWhere("day_of_week = :dayOfWeek", { dayOfWeek })
+      .andWhere("in_effect @> NOW()::date")
+      .execute();
+  }
 }

--- a/app/src/entities/constant-presence/daterange-transformer.ts
+++ b/app/src/entities/constant-presence/daterange-transformer.ts
@@ -1,0 +1,47 @@
+import dayjs, { Dayjs } from "dayjs";
+import { ValueTransformer } from "typeorm";
+
+export type DateRange = {
+  start: Dayjs;
+  end: Dayjs;
+};
+
+/**
+ * Parse Dayjs object from unknown input.
+ *
+ * Returns undefined if the input is empty or cannot be parsed into a valid
+ * date.
+ */
+const parseValidDate = (value: unknown): Dayjs | undefined => {
+  if (!value || typeof value !== "string") {
+    return undefined;
+  }
+
+  const date = dayjs(value);
+  return date.isValid() ? date : undefined;
+};
+
+/**
+ * TypeORM transformer for date ranges.
+ *
+ * Does not account for range inclusivity and exclusivity. Rather always assumes
+ * that range start is inclusive and end is exclusive.
+ */
+export const daterangeTransformer: ValueTransformer = {
+  to: (value: DateRange) => {
+    const format = "YYYY-MM-DD";
+    const start = dayjs(value.start).format(format);
+    const end = dayjs(value.end).format(format);
+
+    return `[${start},${end})`;
+  },
+  from: (value: string): DateRange => {
+    const withoutBraces = value.substring(1, value.length - 1);
+    const parts = withoutBraces.split(",");
+
+    return {
+      start: parseValidDate(parts[0]),
+      end: parseValidDate(parts[1]),
+    };
+  },
+};

--- a/app/src/entities/constant-presence/daterange-transformer.ts
+++ b/app/src/entities/constant-presence/daterange-transformer.ts
@@ -1,9 +1,8 @@
 import dayjs, { Dayjs } from "dayjs";
-import { ValueTransformer } from "typeorm";
 
 export type DateRange = {
-  start: Dayjs;
-  end: Dayjs;
+  start: Dayjs | undefined;
+  end: Dayjs | undefined;
 };
 
 /**
@@ -27,11 +26,11 @@ const parseValidDate = (value: unknown): Dayjs | undefined => {
  * Does not account for range inclusivity and exclusivity. Rather always assumes
  * that range start is inclusive and end is exclusive.
  */
-export const daterangeTransformer: ValueTransformer = {
+export const daterangeTransformer = {
   to: (value: DateRange) => {
     const format = "YYYY-MM-DD";
-    const start = dayjs(value.start).format(format);
-    const end = dayjs(value.end).format(format);
+    const start = value.start ? dayjs(value.start).format(format) : "";
+    const end = value.end ? dayjs(value.end).format(format) : "";
 
     return `[${start},${end})`;
   },

--- a/app/src/entities/constant-presence/dto/create-constant-presence.dto.ts
+++ b/app/src/entities/constant-presence/dto/create-constant-presence.dto.ts
@@ -1,0 +1,5 @@
+import { ConstantPresence } from "../constant-presence.model";
+
+export type CreateConstantPresence = Pick<ConstantPresence, "dayOfWeek" | "remote"> & {
+  officeId: string | undefined;
+};

--- a/app/src/gui/home-tab/views/presence/presence-list.ts
+++ b/app/src/gui/home-tab/views/presence/presence-list.ts
@@ -1,32 +1,26 @@
 import { Injectable } from "@nestjs/common";
-import { Dayjs } from "dayjs";
 import { capitalize } from "lodash";
 import { Context, Header } from "slack-block-builder";
 import { Appendable, ViewBlockBuilder } from "slack-block-builder/dist/internal";
 import dayjs from "../../../../common/dayjs";
-import { Presence } from "../../../../entities/presence/presence.model";
 import { RichText } from "../../../block-builders/rich-text.builder";
-
-type PresenceSearchResult = {
-  date: Dayjs;
-  entries: Presence[];
-};
+import { CommonPresence, PresencesByDate } from "./types";
 
 @Injectable()
 export class PresenceList {
-  build(results: PresenceSearchResult[]): Appendable<ViewBlockBuilder> {
+  build(results: PresencesByDate[]): Appendable<ViewBlockBuilder> {
     return results.flatMap((result) => [
       Header({ text: capitalize(dayjs(result.date).format("dddd D.M.")) }),
-      this.peopleList(result.entries),
+      this.peopleList(result.presences),
     ]);
   }
 
-  private peopleList(entries: Presence[]) {
-    if (entries.length === 0) {
+  private peopleList(presences: CommonPresence[]) {
+    if (presences.length === 0) {
       return Context().elements("Ei ilmoittautumisia valituilla kriteereillä.");
     }
 
-    const sorted = entries.toSorted((a, b) =>
+    const sorted = presences.toSorted((a, b) =>
       a.user.realName.localeCompare(b.user.realName, "fi", { sensitivity: "base" }),
     );
 

--- a/app/src/gui/home-tab/views/presence/presence-view.module.ts
+++ b/app/src/gui/home-tab/views/presence/presence-view.module.ts
@@ -1,4 +1,5 @@
 import { Module } from "@nestjs/common";
+import { ConstantPresenceModule } from "../../../../entities/constant-presence/constant-presence.module";
 import { OfficeModule } from "../../../../entities/office/office.module";
 import { PresenceModule } from "../../../../entities/presence/presence.module";
 import { UserSettingsModule } from "../../../../entities/user-settings/user-settings.module";
@@ -9,7 +10,7 @@ import { PresenceView } from "./presence.view";
 import { UserGroupFilter } from "./user-group-filter";
 
 @Module({
-  imports: [OfficeModule, PresenceModule, UserSettingsModule],
+  imports: [OfficeModule, PresenceModule, UserSettingsModule, ConstantPresenceModule],
   providers: [PresenceView, OfficeFilter, DateFilter, UserGroupFilter, PresenceList],
   exports: [PresenceView],
 })

--- a/app/src/gui/home-tab/views/presence/presence.view.ts
+++ b/app/src/gui/home-tab/views/presence/presence.view.ts
@@ -1,8 +1,11 @@
 import { Injectable } from "@nestjs/common";
 import dayjs, { Dayjs } from "dayjs";
+import { get } from "lodash";
 import { Divider, Header } from "slack-block-builder";
 import { Appendable, ViewBlockBuilder } from "slack-block-builder/dist/internal";
 import { workDayRange } from "../../../../common/work-day-range";
+import { ConstantPresence } from "../../../../entities/constant-presence/constant-presence.model";
+import { ConstantPresenceService } from "../../../../entities/constant-presence/constant-presence.service";
 import { Presence } from "../../../../entities/presence/presence.model";
 import { PresenceService } from "../../../../entities/presence/presence.service";
 import { UserSettings } from "../../../../entities/user-settings/user-settings.model";
@@ -10,6 +13,7 @@ import { UserSettingsService } from "../../../../entities/user-settings/user-set
 import { DateFilter } from "./date-filter";
 import { OfficeFilter } from "./office-filter";
 import { PresenceList } from "./presence-list";
+import { PresencesByDate } from "./types";
 import { UserGroupFilter } from "./user-group-filter";
 
 @Injectable()
@@ -21,6 +25,7 @@ export class PresenceView {
     private userGroupFilter: UserGroupFilter,
     private userSettingsService: UserSettingsService,
     private presenceList: PresenceList,
+    private constantPresenceService: ConstantPresenceService,
   ) {}
 
   async build(userId: string): Promise<Appendable<ViewBlockBuilder>> {
@@ -51,7 +56,7 @@ export class PresenceView {
       ? settings.officeFilter
       : null;
 
-    const entries = await this.presenceService.findByFilter({
+    const precenses = await this.presenceService.findByFilter({
       startDate,
       endDate,
       remote,
@@ -59,22 +64,60 @@ export class PresenceView {
       userGroup: settings.userGroupFilter,
     });
 
-    return this.groupByDateContinuous(entries, dayjs(startDate));
+    const constantPresences = await this.constantPresenceService.findByDateRange(
+      { start: dayjs(startDate), end: dayjs(endDate) },
+      { userGroupHandle: settings.userGroupFilter, officeId, remote },
+    );
+
+    return this.buildDailyPresenceLists(precenses, constantPresences, dayjs(startDate));
   }
 
   /**
-   * Group given presence list by date.
+   * Build presence lists for next 10 working days.
    *
-   * Weekends are excluded but working days are included even if they have no
-   * entries.
+   * The presence lists returned for each day are "exclusive" in the sense that
+   * they are guaranteed to have only one entry per user per day. Manual
+   * presence registrations are preferred over constant presences, if both are
+   * found for the same day.
    */
-  private groupByDateContinuous(entries: Presence[], from: Dayjs) {
+  private buildDailyPresenceLists(
+    presences: Presence[],
+    constantPresences: ConstantPresence[],
+    from: Dayjs,
+  ): PresencesByDate[] {
     const days = workDayRange(10, from);
 
-    const grouped = days.map((date) => ({
-      date,
-      entries: entries.filter((entry) => dayjs(entry.date).isSame(date, "day")),
-    }));
+    const grouped = days.map((date) => {
+      // We want only one presence per user, preferring manual registrations over constant presences.
+      const daysManualEntries = presences.filter((p) => dayjs(p.date).isSame(date, "day"));
+      const daysConstantPresences = constantPresences.filter(
+        (cp) => cp.dayOfWeek === date.weekday(),
+      );
+
+      // Index both arrays by user ID to avoid nested loops.
+      const daysManualEntriesByUser = Object.fromEntries(
+        daysManualEntries.map((p) => [p.user.slackId, p]),
+      );
+      const daysConstantPresencesByUser = Object.fromEntries(
+        daysConstantPresences.map((cp) => [cp.user.slackId, cp]),
+      );
+
+      // Unique values of the union of both lists' keys ensure all users with any entries are included.
+      const usersWithAnyPresence = new Set(
+        Object.keys(daysManualEntriesByUser).concat(Object.keys(daysConstantPresencesByUser)),
+      );
+
+      const effectivePresences = Array.from(usersWithAnyPresence).map((userId) => {
+        const manualRegistration = get(daysManualEntriesByUser, userId);
+        const constantPresence = get(daysConstantPresencesByUser, userId);
+        return manualRegistration || constantPresence;
+      });
+
+      return {
+        date,
+        presences: effectivePresences,
+      };
+    });
 
     return grouped;
   }

--- a/app/src/gui/home-tab/views/presence/types.ts
+++ b/app/src/gui/home-tab/views/presence/types.ts
@@ -1,0 +1,10 @@
+import { Dayjs } from "dayjs";
+import { ConstantPresence } from "../../../../entities/constant-presence/constant-presence.model";
+import { Presence } from "../../../../entities/presence/presence.model";
+
+export type CommonPresence = Pick<Presence, keyof (Presence | ConstantPresence)>;
+
+export type PresencesByDate = {
+  date: Dayjs;
+  presences: CommonPresence[];
+};

--- a/app/src/gui/home-tab/views/registration/day-list-item.ts
+++ b/app/src/gui/home-tab/views/registration/day-list-item.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { Dayjs } from "dayjs";
 import { Actions, Button, Header, Option, OverflowMenu, StaticSelect } from "slack-block-builder";
 import Action from "../../../../bolt/enums/action.enum";
+import { ConstantPresence } from "../../../../entities/constant-presence/constant-presence.model";
 import { Office } from "../../../../entities/office/office.model";
 import { Presence } from "../../../../entities/presence/presence.model";
 
@@ -9,12 +10,14 @@ type DayListItemProps = {
   date: Dayjs;
   offices: Office[];
   presence: Presence | undefined;
+  constantPresence: ConstantPresence | undefined;
 };
 
 @Injectable()
 export class DayListItem {
-  build({ date, offices, presence }: DayListItemProps) {
+  build({ date, offices, presence, constantPresence }: DayListItemProps) {
     const dateString = date.toISOString();
+    const effectivePresence = this.workOutEffectivePresence(presence, constantPresence);
 
     return [
       Header({ text: date.format("dd D.M.") }),
@@ -23,12 +26,12 @@ export class DayListItem {
           text: "Toimistolla",
           actionId: Action.SET_OFFICE_PRESENCE,
           value: dateString,
-        }).primary(presence?.remote === false),
+        }).primary(effectivePresence?.remote === false),
         Button({
           text: "Etänä",
           actionId: Action.SET_REMOTE_PRESENCE,
           value: dateString,
-        }).primary(presence?.remote === true),
+        }).primary(effectivePresence?.remote === true),
         this.getOfficeBlocks(date, offices),
         OverflowMenu({ actionId: Action.DAY_LIST_ITEM_OVERFLOW }).options(
           Option({
@@ -62,5 +65,28 @@ export class DayListItem {
     })
       .initialOption(Options[0])
       .options(Options);
+  }
+
+  /**
+   * Work out effective presence to show from manual registration and constant
+   * presence, both of which are optional.
+   */
+  private workOutEffectivePresence(
+    manual?: Presence,
+    constant?: ConstantPresence,
+  ):
+    | {
+        // This is simple now but the point is to support offices later on...
+        remote: boolean;
+      }
+    | undefined {
+    let remote: boolean | undefined = constant?.remote;
+    remote = manual ? manual.remote : remote;
+
+    if (remote !== undefined) {
+      return { remote };
+    }
+
+    return undefined;
   }
 }

--- a/app/src/gui/home-tab/views/registration/day-list.ts
+++ b/app/src/gui/home-tab/views/registration/day-list.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { flatten } from "lodash";
+import dayjs from "../../../../common/dayjs";
 import { workDayRange } from "../../../../common/work-day-range";
 import { OfficeService } from "../../../../entities/office/office.service";
 import { PresenceService } from "../../../../entities/presence/presence.service";
@@ -8,18 +9,23 @@ import { DayListItem } from "./day-list-item";
 @Injectable()
 export class DayList {
   constructor(
-    private dayListItemBuilder: DayListItem,
+    private dayListItem: DayListItem,
     private officeService: OfficeService,
     private presenceService: PresenceService,
   ) {}
 
   async build(userId: string) {
-    const presences = await this.presenceService.findPresencesByUser(userId);
-    const offices = await this.officeService.findAll();
     const dates = workDayRange(10);
-    const blockLists = dates.map((date) =>
-      this.dayListItemBuilder.build({ date, offices, presences }),
-    );
+    const presences = await this.presenceService.findPresencesByUser(userId);
+
+    const offices = await this.officeService.findAll();
+    const blockLists = dates.map((date) => {
+      const currentPresence = presences.find((presence) =>
+        date.isSame(dayjs(presence.date), "date"),
+      );
+
+      return this.dayListItem.build({ date, offices, presence: currentPresence });
+    });
     return flatten(blockLists);
   }
 }

--- a/app/src/gui/home-tab/views/registration/registration-view.module.ts
+++ b/app/src/gui/home-tab/views/registration/registration-view.module.ts
@@ -1,4 +1,5 @@
 import { Module } from "@nestjs/common";
+import { ConstantPresenceModule } from "../../../../entities/constant-presence/constant-presence.module";
 import { OfficeModule } from "../../../../entities/office/office.module";
 import { PresenceModule } from "../../../../entities/presence/presence.module";
 import { DayList } from "./day-list";
@@ -6,7 +7,7 @@ import { DayListItem } from "./day-list-item";
 import { RegistrationView } from "./registration.view";
 
 @Module({
-  imports: [OfficeModule, PresenceModule],
+  imports: [OfficeModule, PresenceModule, ConstantPresenceModule],
   providers: [DayList, DayListItem, RegistrationView],
   exports: [RegistrationView],
 })

--- a/app/src/gui/home-tab/views/settings/constant-presence-management/constant-presence-management.controller.ts
+++ b/app/src/gui/home-tab/views/settings/constant-presence-management/constant-presence-management.controller.ts
@@ -1,0 +1,18 @@
+import { Controller } from "@nestjs/common";
+import BoltAction from "../../../../../bolt/decorators/bolt-action.decorator";
+import Action from "../../../../../bolt/enums/action.enum";
+import { BoltActionArgs } from "../../../../../bolt/types/bolt-action-args.type";
+import { ConstantPresenceManagementModal } from "./constant-presence-management.modal";
+
+@Controller()
+export class ConstantPresenceManagementController {
+  constructor(private modal: ConstantPresenceManagementModal) {}
+
+  @BoltAction(Action.OPEN_CONSTANT_PRESENCE_MANAGEMENT_MODAL)
+  async openModal({ client, body }: BoltActionArgs) {
+    await client.views.open({
+      trigger_id: body.trigger_id,
+      view: await this.modal.build(),
+    });
+  }
+}

--- a/app/src/gui/home-tab/views/settings/constant-presence-management/constant-presence-management.controller.ts
+++ b/app/src/gui/home-tab/views/settings/constant-presence-management/constant-presence-management.controller.ts
@@ -21,7 +21,7 @@ export class ConstantPresenceManagementController {
   async openModal({ client, body }: BoltActionArgs) {
     await client.views.open({
       trigger_id: body.trigger_id,
-      view: await this.modal.build(),
+      view: await this.modal.build(body.user.id),
     });
   }
 

--- a/app/src/gui/home-tab/views/settings/constant-presence-management/constant-presence-management.controller.ts
+++ b/app/src/gui/home-tab/views/settings/constant-presence-management/constant-presence-management.controller.ts
@@ -1,12 +1,21 @@
-import { Controller } from "@nestjs/common";
+import { Controller, InternalServerErrorException } from "@nestjs/common";
+import { get, range } from "lodash";
 import BoltAction from "../../../../../bolt/decorators/bolt-action.decorator";
+import BoltViewAction from "../../../../../bolt/decorators/bolt-view-action.decorator";
 import Action from "../../../../../bolt/enums/action.enum";
+import ViewAction from "../../../../../bolt/enums/view-action.enum";
 import { BoltActionArgs } from "../../../../../bolt/types/bolt-action-args.type";
+import { BoltViewActionArgs } from "../../../../../bolt/types/bolt-view-action-args.type";
+import { ConstantPresenceService } from "../../../../../entities/constant-presence/constant-presence.service";
+import { CreateConstantPresence } from "../../../../../entities/constant-presence/dto/create-constant-presence.dto";
 import { ConstantPresenceManagementModal } from "./constant-presence-management.modal";
 
 @Controller()
 export class ConstantPresenceManagementController {
-  constructor(private modal: ConstantPresenceManagementModal) {}
+  constructor(
+    private modal: ConstantPresenceManagementModal,
+    private cpService: ConstantPresenceService,
+  ) {}
 
   @BoltAction(Action.OPEN_CONSTANT_PRESENCE_MANAGEMENT_MODAL)
   async openModal({ client, body }: BoltActionArgs) {
@@ -14,5 +23,40 @@ export class ConstantPresenceManagementController {
       trigger_id: body.trigger_id,
       view: await this.modal.build(),
     });
+  }
+
+  @BoltViewAction(ViewAction.SAVE_CONSTANT_PRESENCES)
+  async saveConstantPresences({ body, view }: BoltViewActionArgs) {
+    const inserts = this.insertsFromModalStateValues(view.state.values);
+    await this.cpService.closeOldAndCreateMany(body.user.id, inserts);
+  }
+
+  private presencePropsFromStaticSelectValue(value: unknown) {
+    if (typeof value !== "string") {
+      throw new InternalServerErrorException();
+    }
+
+    if (["REMOTE", "OFFICE"].includes(value)) {
+      return {
+        remote: value === "REMOTE",
+        officeId: null,
+      };
+    }
+
+    return { remote: false, officeId: value };
+  }
+
+  private insertsFromModalStateValues(stateValues: unknown): CreateConstantPresence[] {
+    const valuesForAllDays = range(5).map((dayOfWeek) => ({
+      dayOfWeek,
+      value: get(stateValues, `day-${dayOfWeek}.presence.selected_option.value`),
+    }));
+
+    const selection = valuesForAllDays.filter((o) => o.value);
+
+    return selection.map((selected) => ({
+      dayOfWeek: selected.dayOfWeek,
+      ...this.presencePropsFromStaticSelectValue(selected.value),
+    }));
   }
 }

--- a/app/src/gui/home-tab/views/settings/constant-presence-management/constant-presence-management.modal.ts
+++ b/app/src/gui/home-tab/views/settings/constant-presence-management/constant-presence-management.modal.ts
@@ -1,4 +1,5 @@
 import { Injectable } from "@nestjs/common";
+import { randomUUID } from "crypto";
 import { capitalize, range } from "lodash";
 import {
   Actions,
@@ -11,6 +12,7 @@ import {
   StaticSelect,
 } from "slack-block-builder";
 import { SlackModalDto } from "slack-block-builder/dist/internal";
+import Action from "../../../../../bolt/enums/action.enum";
 import ViewAction from "../../../../../bolt/enums/view-action.enum";
 import dayjs from "../../../../../common/dayjs";
 import { ConstantPresence } from "../../../../../entities/constant-presence/constant-presence.model";
@@ -70,8 +72,12 @@ export class ConstantPresenceManagementModal {
     return [
       Header({ text: capitalize(dayOfWeekName) }),
       Actions({ blockId: `day-${dayOfWeek}` }).elements(
-        StaticSelect({ actionId: "presence" }).options(options).initialOption(initialOption),
-        Button({ text: "Poista ilmoittautuminen" }).danger(),
+        StaticSelect({ actionId: randomUUID() }).options(options).initialOption(initialOption),
+        Button({
+          text: "Poista ilmoittautuminen",
+          actionId: Action.DELETE_CONSTANT_PRESENCE,
+          value: dayOfWeek.toString(),
+        }).danger(),
       ),
     ];
   }

--- a/app/src/gui/home-tab/views/settings/constant-presence-management/constant-presence-management.modal.ts
+++ b/app/src/gui/home-tab/views/settings/constant-presence-management/constant-presence-management.modal.ts
@@ -83,23 +83,23 @@ export class ConstantPresenceManagementModal {
   }
 
   private getInitialOption(
-    existingPresence: ConstantPresence,
+    existingSelection: ConstantPresence,
     options: OptionBuilder[],
   ): OptionBuilder | undefined {
-    if (!existingPresence) {
+    if (!existingSelection) {
       return undefined;
     }
 
-    if (existingPresence.remote) {
+    if (existingSelection.remote) {
       return Option({ text: "Etänä", value: "REMOTE" });
     }
 
-    const initialOption = existingPresence.office
-      ? Option({ text: existingPresence.office.name, value: existingPresence.office.id })
+    const initialOption = existingSelection.office
+      ? Option({ text: existingSelection.office.name, value: existingSelection.office.id })
       : Option({ text: "Toimistolla", value: "OFFICE" });
 
     // Ensure the created option exists to avoid Bolt errors.
-    if (!options.find((opt) => opt.value === initialOption.value)) {
+    if (!options.find((opt) => opt["props"].value === initialOption["props"].value)) {
       return undefined;
     }
 

--- a/app/src/gui/home-tab/views/settings/constant-presence-management/constant-presence-management.modal.ts
+++ b/app/src/gui/home-tab/views/settings/constant-presence-management/constant-presence-management.modal.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { capitalize, range } from "lodash";
 import { Actions, Button, Header, Modal, Option, Section, StaticSelect } from "slack-block-builder";
 import { SlackModalDto } from "slack-block-builder/dist/internal";
+import ViewAction from "../../../../../bolt/enums/view-action.enum";
 import dayjs from "../../../../../common/dayjs";
 import { Office } from "../../../../../entities/office/office.model";
 import { OfficeService } from "../../../../../entities/office/office.service";
@@ -16,7 +17,12 @@ export class ConstantPresenceManagementModal {
       this.constantPresenceSelect(offices, dayOfWeek),
     );
 
-    return Modal({ title: "Vakioilmoittautumiset", submit: "Tallenna", close: "Eiku" })
+    return Modal({
+      title: "Vakioilmoittautumiset",
+      submit: "Tallenna",
+      close: "Eiku",
+      callbackId: ViewAction.SAVE_CONSTANT_PRESENCES,
+    })
       .blocks(
         Section({
           text:
@@ -41,8 +47,8 @@ export class ConstantPresenceManagementModal {
 
     return [
       Header({ text: capitalize(dayOfWeekName) }),
-      Actions().elements(
-        StaticSelect().options(options),
+      Actions({ blockId: `day-${dayOfWeek}` }).elements(
+        StaticSelect({ actionId: "presence" }).options(options),
         Button({ text: "Poista ilmoittautuminen" }).danger(),
       ),
     ];

--- a/app/src/gui/home-tab/views/settings/constant-presence-management/constant-presence-management.modal.ts
+++ b/app/src/gui/home-tab/views/settings/constant-presence-management/constant-presence-management.modal.ts
@@ -1,12 +1,50 @@
 import { Injectable } from "@nestjs/common";
-import { Header, Modal } from "slack-block-builder";
+import { capitalize, range } from "lodash";
+import { Actions, Button, Header, Modal, Option, Section, StaticSelect } from "slack-block-builder";
 import { SlackModalDto } from "slack-block-builder/dist/internal";
+import dayjs from "../../../../../common/dayjs";
+import { Office } from "../../../../../entities/office/office.model";
+import { OfficeService } from "../../../../../entities/office/office.service";
 
 @Injectable()
 export class ConstantPresenceManagementModal {
+  constructor(private officeService: OfficeService) {}
+
   async build(): Promise<Readonly<SlackModalDto>> {
-    return Modal({ title: "Vakioilmoittautumiset" })
-      .blocks(Header({ text: "hehe" }))
+    const offices = await this.officeService.findAll();
+    const selectBlocks = range(5).map((dayOfWeek) =>
+      this.constantPresenceSelect(offices, dayOfWeek),
+    );
+
+    return Modal({ title: "Vakioilmoittautumiset", submit: "Tallenna", close: "Eiku" })
+      .blocks(
+        Section({
+          text:
+            "Voit asettaa joka viikko toistuvia ilmoittautumisia. Kaiku näyttää " +
+            "vakioilmoittautumisesi kunakin päivänä, mikäli et tee käsin toista ilmoittautumista.",
+        }),
+        ...selectBlocks,
+      )
       .buildToObject();
+  }
+
+  private constantPresenceSelect(offices: Office[], dayOfWeek: number) {
+    const options = offices.map((office) => Option({ text: office.name, value: office.id }));
+
+    if (!options.length) {
+      options.push(Option({ text: "Toimistolla", value: "OFFICE" }));
+    }
+
+    options.push(Option({ text: "Etänä", value: "REMOTE" }));
+
+    const dayOfWeekName = dayjs().weekday(dayOfWeek).format("dddd");
+
+    return [
+      Header({ text: capitalize(dayOfWeekName) }),
+      Actions().elements(
+        StaticSelect().options(options),
+        Button({ text: "Poista ilmoittautuminen" }).danger(),
+      ),
+    ];
   }
 }

--- a/app/src/gui/home-tab/views/settings/constant-presence-management/constant-presence-management.modal.ts
+++ b/app/src/gui/home-tab/views/settings/constant-presence-management/constant-presence-management.modal.ts
@@ -1,0 +1,12 @@
+import { Injectable } from "@nestjs/common";
+import { Header, Modal } from "slack-block-builder";
+import { SlackModalDto } from "slack-block-builder/dist/internal";
+
+@Injectable()
+export class ConstantPresenceManagementModal {
+  async build(): Promise<Readonly<SlackModalDto>> {
+    return Modal({ title: "Vakioilmoittautumiset" })
+      .blocks(Header({ text: "hehe" }))
+      .buildToObject();
+  }
+}

--- a/app/src/gui/home-tab/views/settings/constant-presence-management/constant-presence-management.module.ts
+++ b/app/src/gui/home-tab/views/settings/constant-presence-management/constant-presence-management.module.ts
@@ -1,8 +1,10 @@
 import { Module } from "@nestjs/common";
+import { OfficeModule } from "../../../../../entities/office/office.module";
 import { ConstantPresenceManagementController } from "./constant-presence-management.controller";
 import { ConstantPresenceManagementModal } from "./constant-presence-management.modal";
 
 @Module({
+  imports: [OfficeModule],
   providers: [ConstantPresenceManagementModal],
   controllers: [ConstantPresenceManagementController],
 })

--- a/app/src/gui/home-tab/views/settings/constant-presence-management/constant-presence-management.module.ts
+++ b/app/src/gui/home-tab/views/settings/constant-presence-management/constant-presence-management.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { ConstantPresenceManagementController } from "./constant-presence-management.controller";
+import { ConstantPresenceManagementModal } from "./constant-presence-management.modal";
+
+@Module({
+  providers: [ConstantPresenceManagementModal],
+  controllers: [ConstantPresenceManagementController],
+})
+export class ConstantPresenceManagementModule {}

--- a/app/src/gui/home-tab/views/settings/constant-presence-management/constant-presence-management.module.ts
+++ b/app/src/gui/home-tab/views/settings/constant-presence-management/constant-presence-management.module.ts
@@ -1,10 +1,11 @@
 import { Module } from "@nestjs/common";
+import { ConstantPresenceModule } from "../../../../../entities/constant-presence/constant-presence.module";
 import { OfficeModule } from "../../../../../entities/office/office.module";
 import { ConstantPresenceManagementController } from "./constant-presence-management.controller";
 import { ConstantPresenceManagementModal } from "./constant-presence-management.modal";
 
 @Module({
-  imports: [OfficeModule],
+  imports: [OfficeModule, ConstantPresenceModule],
   providers: [ConstantPresenceManagementModal],
   controllers: [ConstantPresenceManagementController],
 })

--- a/app/src/gui/home-tab/views/settings/settings-view.module.ts
+++ b/app/src/gui/home-tab/views/settings/settings-view.module.ts
@@ -2,12 +2,19 @@ import { Module } from "@nestjs/common";
 import { AuthorizationModule } from "../../../../authorization/authorization.module";
 import { OfficeModule } from "../../../../entities/office/office.module";
 import { UserSettingsModule } from "../../../../entities/user-settings/user-settings.module";
+import { ConstantPresenceManagementModule } from "./constant-presence-management/constant-presence-management.module";
 import { OfficeManagementModule } from "./office-management/office-management.module";
 import { SettingsViewController } from "./settings-view.controller";
 import { SettingsView } from "./settings.view";
 
 @Module({
-  imports: [OfficeManagementModule, OfficeModule, UserSettingsModule, AuthorizationModule],
+  imports: [
+    AuthorizationModule,
+    ConstantPresenceManagementModule,
+    OfficeManagementModule,
+    OfficeModule,
+    UserSettingsModule,
+  ],
   providers: [SettingsView],
   controllers: [SettingsViewController],
   exports: [SettingsView],

--- a/app/src/gui/home-tab/views/settings/settings.view.ts
+++ b/app/src/gui/home-tab/views/settings/settings.view.ts
@@ -29,6 +29,12 @@ export class SettingsView {
     return [
       Header({ text: "Asetukset" }),
       this.getHomeOfficeSelect(offices, settings),
+      Actions().elements(
+        Button({
+          text: "Vakioilmoittautumiset",
+          actionId: Action.OPEN_CONSTANT_PRESENCE_MANAGEMENT_MODAL,
+        }),
+      ),
       officeMgmtButton,
     ];
   }


### PR DESCRIPTION
- Users can create, edit, and delete "constant presences" through settings view. These are essentially recurring registrations to an office or remote work.
- Constant presences are shown in the registration and presence views if manual registrations are not found.

Note: Registration view ("Ilmoittautuminen") does not support multiple offices yet. The drop-down is just a remnant from drafting the view's layout. I will fix that in an upcoming PR to keep PR sizes reasonable ✌️ 