### PR TITLE
Add documentation and manifest for Slack app installation

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -19,6 +19,7 @@ USER node
 WORKDIR /app
 COPY --from=build /usr/src/app/dist ./dist
 COPY --from=build /usr/src/app/node_modules ./node_modules
+COPY --from=build /usr/src/app/manifest.yaml ./manifest.yaml
 
 # Run database migrations before booting server.
 CMD npx typeorm migration:run -d dist/database/migration-config.js && node dist/main.js

--- a/app/manifest.yaml
+++ b/app/manifest.yaml
@@ -1,0 +1,25 @@
+# Slack App Manifest
+# See https://api.slack.com/concepts/manifests
+display_information:
+  name: Kaiku
+  description: Hybridityöskentelyn tukisovellus
+features:
+  app_home:
+    home_tab_enabled: true
+    messages_tab_enabled: false
+  bot_user:
+    display_name: kaiku
+    always_online: true
+oauth_config:
+  scopes:
+    bot:
+      - usergroups:read
+      - users:read
+settings:
+  event_subscriptions:
+    bot_events:
+      - app_home_opened
+      - user_profile_changed
+  interactivity:
+    is_enabled: true
+  socket_mode_enabled: true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,7 @@ Kaiku is configured using environment variables.
 | `DATABASE_USERNAME`    |    ✅    | Postgres username.                                                                                                                   |
 | `DATABASE_PASSWORD`    |    ✅    | Postgres password.                                                                                                                   |
 | `DATABASE_SSL_ENABLED` |          | Use SSL to connect to the Postgres server if set to `"true"`. Disabled by default.                                                   |
+| `DATABASE_SSL_MODE`    |          | When set to `true`, TypeORM is configured to use SSL mode `no-verify` when connecting to Postgres. Otherwise, SSL is disabled.       |
 | `SLACK_APP_TOKEN`      |    ✅    | App-level token from Slack to authenticate the WebSocket connection.                                                                 |
 | `SLACK_BOT_TOKEN`      |    ✅    | OAuth token for Kaiku's bot user.                                                                                                    |
 | `SLACK_SIGNING_SECRET` |    ✅    | Slack signing secret.                                                                                                                |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,34 @@
+# Installation
+
+Kaiku is distributed as a self-hosted Slack app. This means that you must provide the runtime
+environment for it. Slack will only take care of interfacing with Kaiku via WebSocket, not run it or
+persist the data.
+
+See [Requirements](./requirements.md) and [Configuration](./configuration.md) for information on how
+to run Kaiku itself.
+
+## Create Slack App
+
+1. Sign in to your Slack workspace.
+2. [Create a new Slack app](https://api.slack.com/apps) using
+   [Kaiku's manifest](../app/manifest.yaml). Make sure to use the manifest matching the version of
+   Kaiku you are running (the correct manifest is also included in our released Docker images).
+3. Fill in other details according to Slack's instructions.
+
+## Configure Kaiku
+
+### Signing Secret
+
+The signing secret is found on your app's settings page under _Basic information_. Populate the
+`SLACK_SIGNING_SECRET` with its value.
+
+### App Token
+
+The app-level token is found also on your app's settings page under _App-Level tokens_. You must
+create a new token when you install an app for the first time and add the `connections:write` scope
+for it. Populate the `SLACK_APP_TOKEN` with its value.
+
+### Bot Token
+
+The signing secret is found on your app's settings page under _OAuth & Permissions_. Populate the
+`SLACK_BOT_TOKEN` with its value.


### PR DESCRIPTION
I added the manifest to the Docker image as well, because I thought it would be the easiest place for Ansible workflows to pull it from and be sure that it always matches the Kaiku version being deployed.