### PR TITLE
Fix Docker production image build

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -20,6 +20,6 @@ WORKDIR /app
 COPY --from=build /usr/src/app/dist ./dist
 COPY --from=build /usr/src/app/node_modules ./node_modules
 COPY --from=build /usr/src/app/manifest.yaml ./manifest.yaml
+COPY --from=build /usr/src/app/entrypoint.sh ./entrypoint.sh
 
-# Run database migrations before booting server.
-CMD npx typeorm migration:run -d dist/database/migration-config.js && node dist/main.js
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Entrypoint script for production image as recommended in
+# https://docs.docker.com/reference/build-checks/json-args-recommended/#create-a-wrapper-script
+
+set -e
+npx typeorm migration:run -d dist/database/migration-config.js
+node dist/main.js

--- a/app/src/database/migration-config.ts
+++ b/app/src/database/migration-config.ts
@@ -18,5 +18,5 @@ export default new DataSource({
    * that using no wildcards resolves to different paths between the two. This
    * is arguably a little iffy but perhaps sufficient.
    */
-  migrations: ["**/migrations/*.ts"],
+  migrations: ["**/migrations/*.{js,ts}"],
 });

--- a/app/src/database/migrations/1726034817829-create-user-table.ts
+++ b/app/src/database/migrations/1726034817829-create-user-table.ts
@@ -20,13 +20,13 @@ export class CreateUserTable1726034817829 implements MigrationInterface {
             type: "text",
           },
           {
-            name: "user_settings_id",
+            name: "settings_id",
             type: "uuid",
           },
         ],
         foreignKeys: [
           {
-            columnNames: ["user_settings_id"],
+            columnNames: ["settings_id"],
             referencedTableName: "user_settings",
             referencedColumnNames: ["id"],
             onDelete: "cascade",

--- a/app/src/database/migrations/1729339277187-change-visible-office-to-office-filter.ts
+++ b/app/src/database/migrations/1729339277187-change-visible-office-to-office-filter.ts
@@ -12,7 +12,7 @@ export class ChangeVisibleOfficeToOfficeFilter1729339277187 implements Migration
 
     await queryRunner.addColumn(
       table,
-      new TableColumn({ name: "officer_filter", type: "text", default: "'ALL_OFFICES'::text" }),
+      new TableColumn({ name: "office_filter", type: "text", default: "'ALL_OFFICES'::text" }),
     );
   }
 

--- a/app/src/database/migrations/1735653188488-create-constant-presence-table.ts
+++ b/app/src/database/migrations/1735653188488-create-constant-presence-table.ts
@@ -37,6 +37,7 @@ export class AddConstantPresenceTable1735653188488 implements MigrationInterface
           {
             name: "office_id",
             type: "uuid",
+            isNullable: true,
           },
           {
             name: "created_at",

--- a/app/src/entities/user/user.model.ts
+++ b/app/src/entities/user/user.model.ts
@@ -13,7 +13,7 @@ export class User {
   realName: string;
 
   @OneToOne(() => UserSettings, { cascade: true, eager: true })
-  @JoinColumn()
+  @JoinColumn({ name: "settings_id" })
   settings: UserSettings;
 }
 

--- a/app/tsconfig.build.json
+++ b/app/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "jest.config*"]
 }


### PR DESCRIPTION
Fix problems preventing production image from being run:

- Unnecessary files included in TS build added an extra directory level to built code which in turn caused the configuration file path passed to TypeORM to be wrong.
- Migration configuration was not including built JS files.
- Multiple typos and small mistakes in migration files.
- BONUS: Replaced `CMD` with `ENTRYPOINT` [as recommended by Docker](https://docs.docker.com/reference/build-checks/json-args-recommended/#create-a-wrapper-script).

Once we have integration tests, I will look into running them against migrated database (rather than auto-generated schema) to prevent such mistakes in the future.