### PR TITLE
Fix configuration (wrong environment variable name)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kaiku-app",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kaiku-app",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "GPL-3.0",
       "dependencies": {
         "@golevelup/nestjs-discovery": "^4.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kaiku-app",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "Joonas Häkkinen <joonas.hakkinen@funidata.fi>",
   "license": "GPL-3.0",
   "private": true,

--- a/app/src/database/migration-config.ts
+++ b/app/src/database/migration-config.ts
@@ -12,7 +12,7 @@ export default new DataSource({
    * modes are not supported. See
    * https://github.com/brianc/node-postgres/tree/master/packages/pg-connection-string#tcp-connections
    */
-  ssl: process.env.DATABASE_SSL_MODE === "true" ? { rejectUnauthorized: false } : false,
+  ssl: process.env.DATABASE_SSL_ENABLED === "true" ? { rejectUnauthorized: false } : false,
   /**
    * Glob pattern is used to make this work both locally and in CI as it appears
    * that using no wildcards resolves to different paths between the two. This

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,8 +11,7 @@ Kaiku is configured using environment variables.
 | `DATABASE_PORT`        |    ✅    | Postgres server port.                                                                                                                |
 | `DATABASE_USERNAME`    |    ✅    | Postgres username.                                                                                                                   |
 | `DATABASE_PASSWORD`    |    ✅    | Postgres password.                                                                                                                   |
-| `DATABASE_SSL_ENABLED` |          | Use SSL to connect to the Postgres server if set to `"true"`. Disabled by default.                                                   |
-| `DATABASE_SSL_MODE`    |          | When set to `true`, TypeORM is configured to use SSL mode `no-verify` when connecting to Postgres. Otherwise, SSL is disabled.       |
+| `DATABASE_SSL_ENABLED` |          | When set to `true`, TypeORM is configured to use SSL mode `no-verify` when connecting to Postgres. Otherwise, SSL is disabled.       |
 | `SLACK_APP_TOKEN`      |    ✅    | App-level token from Slack to authenticate the WebSocket connection.                                                                 |
 | `SLACK_BOT_TOKEN`      |    ✅    | OAuth token for Kaiku's bot user.                                                                                                    |
 | `SLACK_SIGNING_SECRET` |    ✅    | Slack signing secret.                                                                                                                |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kaiku",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kaiku",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kaiku",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Kaiku Slackbot",
   "scripts": {
     "start": "docker compose up -d && npm run logs",


### PR DESCRIPTION
Migration config used `DATABASE_SSL_MODE` and app config `DATABASE_SSL_ENABLED`. Fixed migration config to use the latter.